### PR TITLE
replace bigi with big-integer

### DIFF
--- a/lib/determination.js
+++ b/lib/determination.js
@@ -1,5 +1,5 @@
 const Prando = require('./Prando');
-const BigInteger = require('bigi');
+const bigInt = require('big-integer');
 const config = require('./config');
 const utils = require('./utils');
 
@@ -111,13 +111,13 @@ const getQuorumForDapi = (mnList, calcHash, vin, full) => {
 const getQuorumForUser = (mnList, calcHash, txid, full) => {
   const quorums = getAllQuorums(mnList, calcHash, full);
 
-  let distance1 = BigInteger.ZERO;
+  let distance1 = bigInt.zero;
   let qWin = [];
 
   quorums.forEach((quorum) => {
     // distance2 = distance between the candidate quorum's hash and the regTxID
     // the quorum with the closest distance wins
-    const distance2 = Math.abs(BigInteger.fromHex(quorum.hash).subtract(BigInteger.fromHex(txid)));
+    const distance2 = bigInt(quorum.hash, 16).minus(bigInt(txid, 16)).abs();
 
     if (distance2 > distance1) {
       distance1 = distance2;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,6 @@
 const _ = require('lodash');
 const sha256 = require('sha256');
-const BigInteger = require('bigi');
+const bigInt = require('big-integer');
 const ip = require('ip');
 const config = require('./config');
 
@@ -46,7 +46,7 @@ const revHex = (s) => {
 
 // TODO: Rethink the algorithm to avoid potentially unnecessary mutation
 const getAverageHash = (array) => {
-  let avgHash = BigInteger.ZERO;
+  let avgHash = bigInt.zero;
 
   array.forEach((element) => {
     let hash;
@@ -59,12 +59,12 @@ const getAverageHash = (array) => {
       throw new Error('unexpected input for getAverageHash()');
     }
 
-    const bigint = BigInteger.fromHex(hash);
+    const bigint = bigInt(hash, 16);
     avgHash = avgHash.add(bigint);
   });
 
-  avgHash = avgHash.divide(BigInteger.fromString(array.length.toString()));
-  return avgHash.toHex();
+  avgHash = avgHash.divide(bigInt(array.length));
+  return avgHash.toString(16);
 };
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/dashevo/quorums-dash#readme",
   "dependencies": {
-    "bigi": "git+ssh://git@github.com/dashevo/bigi.git",
+    "big-integer": "^1.6.26",
     "bitcore-message-dash": "^1.0.9",
     "ip": "^1.1.5",
     "lodash": "^4.17.5",


### PR DESCRIPTION
I ran into a problem with bigi.js with the new version of orbitDB. OrbitDB now uses the js implementation of ipfs instead of ipfs-api and ipfs.js includes a dependency which uses an older version of bigi.js with a different constructor. I went ahead and just replaced the abondoned bigi.js with a much more used biginteger library: big-integer.js: https://www.npmjs.com/package/big-integer . I think this library is sufficiently distributed and in active development to leave this dependency and not fork it to dashevo